### PR TITLE
Platform data fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,3 @@ region = eu-north-1
 ```
 
 3. Run `cdk deploy`
-
-# Test
-To update snapshots, run `tox -- --snapshot-update`

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ L0FetcherStack(
     "L0FetcherStack",
     output_bucket_name="mats-l0-raw",
     config_ssm_name="/rclone/l0-fetcher",
+    source_path="/pub/OPS/TM/",
     full_sync=False,
 )
 

--- a/app.py
+++ b/app.py
@@ -5,12 +5,22 @@ from aws_cdk import App
 from fetcher.l0_fetcher_stack import L0FetcherStack
 
 app = App()
+
 L0FetcherStack(
     app,
-    "L0FetcherStack",
-    output_bucket_name="mats-l0-raw",
+    "L0RACFetcherStack",
+    output_bucket_name="mats-l0-raw-rac",
     config_ssm_name="/rclone/l0-fetcher",
-    source_path="/pub/OPS/TM/",
+    source_path="/pub/OPS/TM/Level0/",
+    full_sync=False,
+)
+
+L0FetcherStack(
+    app,
+    "L0PlatformFetcherStack",
+    output_bucket_name="mats-l0-raw-platform",
+    config_ssm_name="/rclone/l0-fetcher",
+    source_path="/pub/OPS/TM/Level1A/Platform/",
     full_sync=False,
 )
 

--- a/fetcher/handlers/l0_fetcher.py
+++ b/fetcher/handlers/l0_fetcher.py
@@ -1,13 +1,14 @@
 import logging
+import os
 import subprocess
 import tempfile
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
 import boto3
 
-
 BotoClient = Any
 Event = Dict[str, Any]
+Context = Any
 
 
 def get_rclone_config_path(
@@ -46,16 +47,16 @@ def format_command(
     return cmd
 
 
-def lambda_handler(event: Event, _):
+def lambda_handler(event: Event, context: Context):
     ssm_client: BotoClient = boto3.client("ssm")
 
     config_path = get_rclone_config_path(
         ssm_client,
-        event.get("RCLONE_CONFIG_SSM_NAME", "config")
+        os.environ.get("RCLONE_CONFIG_SSM_NAME", "config")
     )
-    bucket = event.get("OUTPUT_BUCKET", "bucket")
-    full_sync = event.get("FULL_SYNC", "FALSE").upper() != "FALSE"
-    source_path = event.get("SOURCE_PATH", "/")
+    bucket = os.environ.get("OUTPUT_BUCKET", "bucket")
+    full_sync = os.environ.get("FULL_SYNC", "FALSE").upper() != "FALSE"
+    source_path = os.environ.get("SOURCE_PATH", "/")
 
     cmd = format_command(config_path, source_path, bucket, full_sync)
 

--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -23,6 +23,7 @@ class L0FetcherStack(Stack):
         id: str,
         output_bucket_name: str,
         config_ssm_name: str,
+        source_path: str,
         full_sync: bool = False,
         lambda_timeout: Duration = Duration.seconds(300),
         lambda_schedule: Schedule = Schedule.rate(Duration.hours(12)),
@@ -55,6 +56,7 @@ class L0FetcherStack(Stack):
             runtime=Runtime.PYTHON_3_9,
             environment={
                 "RCLONE_CONFIG_SSM_NAME": config_ssm_name,
+                "SOURCE_PATH": source_path,
                 "OUTPUT_BUCKET": output_bucket_name,
                 "FULL_SYNC": str(full_sync),
             },

--- a/tests/fetcher/handlers/test_l0_fetcher.py
+++ b/tests/fetcher/handlers/test_l0_fetcher.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import botocore
 from botocore.stub import Stubber
 from fetcher.handlers.l0_fetcher import (
-    FTP_PATH,
     format_command,
     get_rclone_config_path,
 )
@@ -33,13 +32,13 @@ def test_rclone_config_path():
 
 
 def test_format_command_full_sync():
-    assert format_command("config", "bucket", True) == [
-        "rclone", "--config", "config", "sync", f"FTP:{FTP_PATH}", "S3:bucket"
+    assert format_command("config", "path", "bucket", True) == [
+        "rclone", "--config", "config", "sync", "FTP:path", "S3:bucket"
     ]
 
 
 def test_format_command_partial_sync():
-    assert format_command("config", "bucket", False) == [
-        "rclone", "--config", "config", "sync", f"FTP:{FTP_PATH}", "S3:bucket",
+    assert format_command("config", "path", "bucket", False) == [
+        "rclone", "--config", "config", "sync", "FTP:path", "S3:bucket",
         "--update", "--use-server-modtime", "--max-age", "7d"
     ]

--- a/tests/fetcher/test_l0_fetcher_stack.py
+++ b/tests/fetcher/test_l0_fetcher_stack.py
@@ -16,6 +16,7 @@ def template():
         "lambdastack",
         "output-bucket",
         "config-ssm",
+        "source_path",
     )
 
     return Template.from_stack(stack)
@@ -69,6 +70,7 @@ class TestL0FetcherStack:
             "lambdastack",
             "output-bucket",
             "config-ssm",
+            "source_path",
             full_sync,
             Duration.seconds(timeout),
         )
@@ -104,6 +106,7 @@ class TestL0FetcherStack:
             "lambdastack",
             "output-bucket",
             "config-ssm",
+            "source_path",
             lambda_schedule=Schedule.rate(Duration.hours(rate)),
         )
         template = Template.from_stack(stack)


### PR DESCRIPTION
This PR adds deployment of another fetcher to get platform data. Not 100% sure about the paths but that can be easily changed when we go live.

To enable this, a small tweak in the lambda handler was necessary to be able to set the source path.

Part of https://github.com/innosat-mats/rac-extract-payload/issues/141 