### PR TITLE
Add notifications to SQS

### DIFF
--- a/fetcher/handlers/l0_fetcher.py
+++ b/fetcher/handlers/l0_fetcher.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import subprocess
@@ -9,6 +10,19 @@ import boto3
 BotoClient = Any
 Event = Dict[str, Any]
 Context = Any
+
+
+class SyncError(Exception):
+    pass
+
+
+def get_or_raise(variable_name: str) -> str:
+    var = os.environ.get(variable_name)
+    if var is None:
+        raise EnvironmentError(
+            f"{variable_name} is a required environment variable"
+        )
+    return var
 
 
 def get_rclone_config_path(
@@ -39,6 +53,9 @@ def format_command(
         "sync",
         f"FTP:{source_path}",
         f"S3:{bucket}",
+        "-v",
+        "--use-json-log",
+        "--stats-one-line",
     ]
 
     if not full_sync:
@@ -47,21 +64,58 @@ def format_command(
     return cmd
 
 
+def parse_log(log: str) -> List[str]:
+    def keep(row: Dict[str, str]) -> bool:
+        return row["msg"] != "Deleted"
+
+    return [
+        parsed_row["object"]
+        for parsed_row in [json.loads(row) for row in log.splitlines()]
+        if "object" in parsed_row and keep(parsed_row)
+    ]
+
+
+def notify_queue(
+    sqs_client: BotoClient,
+    notification_queue: str,
+    modified_files: List[str],
+    bucket: str,
+) -> None:
+    response = sqs_client.send_message(
+        QueueUrl=notification_queue,
+        MessageBody=json.dumps({
+            "objects": modified_files,
+            "bucket": bucket,
+        })
+    )
+    if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+        msg = f"Failed to notify queue: {response}"
+        logging.error(msg)
+        raise SyncError(msg)
+
+
 def lambda_handler(event: Event, context: Context):
     ssm_client: BotoClient = boto3.client("ssm")
+    sqs_client: BotoClient = boto3.client("sqs")
 
     config_path = get_rclone_config_path(
         ssm_client,
         os.environ.get("RCLONE_CONFIG_SSM_NAME", "config")
     )
-    bucket = os.environ.get("OUTPUT_BUCKET", "bucket")
+    bucket = get_or_raise("OUTPUT_BUCKET")
+    source_path = get_or_raise("SOURCE_PATH")
+    notification_queue = get_or_raise("NOTIFICATION_QUEUE")
     full_sync = os.environ.get("FULL_SYNC", "FALSE").upper() != "FALSE"
-    source_path = os.environ.get("SOURCE_PATH", "/")
 
     cmd = format_command(config_path, source_path, bucket, full_sync)
 
     out = subprocess.run(cmd, capture_output=True)
-    if out.returncode == 0:
-        logging.info("Files successfully synced")
-    else:
+    if out.returncode != 0:
         logging.error(out.stderr)
+        raise SyncError(out.stderr.decode())
+
+    logging.info("Files successfully synced")
+
+    modified_files = parse_log(out.stderr.decode())
+    notify_queue(sqs_client, notification_queue, modified_files, bucket)
+    logging.info("Notified queue")

--- a/fetcher/handlers/l0_fetcher.py
+++ b/fetcher/handlers/l0_fetcher.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import subprocess
 import tempfile
@@ -89,7 +88,6 @@ def notify_queue(
     )
     if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
         msg = f"Failed to notify queue: {response}"
-        logging.error(msg)
         raise SyncError(msg)
 
 
@@ -110,11 +108,7 @@ def lambda_handler(event: Event, context: Context):
 
     out = subprocess.run(cmd, capture_output=True)
     if out.returncode != 0:
-        logging.error(out.stderr)
         raise SyncError(out.stderr.decode())
-
-    logging.info("Files successfully synced")
 
     modified_files = parse_log(out.stderr.decode())
     notify_queue(sqs_client, notification_queue, modified_files, bucket)
-    logging.info("Notified queue")

--- a/fetcher/handlers/l0_fetcher.py
+++ b/fetcher/handlers/l0_fetcher.py
@@ -17,8 +17,7 @@ class SyncError(Exception):
 
 
 def get_or_raise(variable_name: str) -> str:
-    var = os.environ.get(variable_name)
-    if var is None:
+    if (var := os.environ.get(variable_name)) is None:
         raise EnvironmentError(
             f"{variable_name} is a required environment variable"
         )

--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -91,6 +91,6 @@ class L0FetcherStack(Stack):
         CfnOutput(
             self,
             "QueueOutput",
-            value=notification_queue.queue_name,
+            value=notification_queue.queue_arn,
             export_name=f"{id}OutputQueue",
         )

--- a/tests/fetcher/handlers/test_l0_fetcher.py
+++ b/tests/fetcher/handlers/test_l0_fetcher.py
@@ -1,11 +1,32 @@
+import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import botocore
+import pytest  # type: ignore
 from botocore.stub import Stubber
 from fetcher.handlers.l0_fetcher import (
+    SyncError,
     format_command,
+    get_or_raise,
     get_rclone_config_path,
+    notify_queue,
+    parse_log,
 )
+
+
+@patch.dict(os.environ, {"DEFINITELY": "set"})
+def test_get_or_raise():
+    assert get_or_raise("DEFINITELY") == "set"
+
+
+def test_get_or_raise_raises():
+    with pytest.raises(
+        EnvironmentError,
+        match="DEFINITELYNOT is a required environment variable"
+    ):
+        get_or_raise("DEFINITELYNOT")
 
 
 def test_rclone_config_path():
@@ -33,12 +54,72 @@ def test_rclone_config_path():
 
 def test_format_command_full_sync():
     assert format_command("config", "path", "bucket", True) == [
-        "rclone", "--config", "config", "sync", "FTP:path", "S3:bucket"
+        "rclone", "--config", "config", "sync", "FTP:path", "S3:bucket", "-v",
+        "--use-json-log", "--stats-one-line",
     ]
 
 
 def test_format_command_partial_sync():
     assert format_command("config", "path", "bucket", False) == [
-        "rclone", "--config", "config", "sync", "FTP:path", "S3:bucket",
-        "--update", "--use-server-modtime", "--max-age", "7d"
+        "rclone", "--config", "config", "sync", "FTP:path", "S3:bucket", "-v",
+        "--use-json-log", "--stats-one-line", "--update",
+        "--use-server-modtime", "--max-age", "7d",
     ]
+
+
+def test_parse_log():
+    log = '{"level":"info","msg":"Copied (new)","object":"added","objectType":"*local.Object","source":"operations/operations.go:537","time":"2022-11-03T11:30:06.105602+01:00"}\n{"level":"info","msg":"Updated modification time in destination","object":"modified","objectType":"*local.Object","source":"operations/operations.go:262","time":"2022-11-03T11:30:06.105604+01:00"}\n{"level":"info","msg":"Deleted","object":"deleted","objectType":"*local.Object","source":"operations/operations.go:686","time":"2022-11-03T11:30:06.105715+01:00"}\n{"level":"info","msg":"          0 B / 0 B, -, 0 B/s, ETA -\\n","source":"accounting/stats.go:480","stats":{"bytes":0,"checks":2,"deletedDirs":0,"deletes":1,"elapsedTime":0.029543744,"errors":0,"eta":null,"fatalError":false,"renames":0,"retryError":false,"speed":0,"totalBytes":0,"totalChecks":2,"totalTransfers":1,"transferTime":0,"transfers":1},"time":"2022-11-03T11:30:06.105767+01:00"}\n'  # noqa: E501
+    assert parse_log(log) == ["added", "modified"]
+
+
+def test_notify_queue():
+    queue_url = "queueurl"
+    list_of_files = ["files"]
+    bucket = "bucket"
+
+    sqs_client = botocore.session.get_session().create_client(
+        "sqs",
+        region_name="eu-north-1"
+    )
+    stubber = Stubber(sqs_client)
+    stubber.add_response(
+        "send_message",
+        {"ResponseMetadata": {"HTTPStatusCode": 200}},
+        expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
+            "objects": list_of_files,
+            "bucket": bucket,
+        })}
+
+    )
+    stubber.activate()
+
+    notify_queue(sqs_client, queue_url, list_of_files, bucket)
+
+
+def test_notify_queue_raises():
+    queue_url = "queueurl"
+    list_of_files = ["files"]
+    bucket = "bucket"
+
+    sqs_client = botocore.session.get_session().create_client(
+        "sqs",
+        region_name="eu-north-1"
+    )
+    stubber = Stubber(sqs_client)
+    response = {
+        "MD5OfMessageBody": "Other useful information",
+        "ResponseMetadata": {"HTTPStatusCode": 404}
+    }
+    stubber.add_response(
+        "send_message",
+        response,
+        expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
+            "objects": list_of_files,
+            "bucket": bucket,
+        })}
+
+    )
+    stubber.activate()
+
+    with pytest.raises(SyncError, match=f'Failed to notify queue: {response}'):
+        notify_queue(sqs_client, queue_url, list_of_files, bucket)


### PR DESCRIPTION
- Add parsing of Rclone logs. This extracts a list of the files that were added or modified
- Publish message to SQS with the list of files
- The SQS queue is created in the lambda's Stack and the name of the queue is exported as a cloudformation Output, to enable  easy importing of the queue in other stacks.

Part of https://github.com/innosat-mats/rac-extract-payload/issues/141
