### PR TITLE
Send notifications to FIFO queue

### DIFF
--- a/fetcher/handlers/l0_fetcher.py
+++ b/fetcher/handlers/l0_fetcher.py
@@ -84,7 +84,8 @@ def notify_queue(
         response = sqs_client.send_message(
             QueueUrl=notification_queue,
             MessageBody=json.dumps({
-                "object": f"{bucket}/{file}",
+                "object": file,
+                "bucket": bucket,
             })
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:

--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -43,6 +43,7 @@ class L0FetcherStack(Stack):
         notification_queue = Queue(
             self,
             "L0FetcherNotificationQueue",
+            fifo=True,
             retention_period=queue_retention,
             visibility_timeout=queue_visibility_timeout,
         )
@@ -60,7 +61,7 @@ class L0FetcherStack(Stack):
             handler="l0_fetcher.lambda_handler",
             timeout=lambda_timeout,
             architecture=Architecture.X86_64,
-            memory_size=256,
+            memory_size=512,
             runtime=Runtime.PYTHON_3_9,
             environment={
                 "RCLONE_CONFIG_SSM_NAME": config_ssm_name,

--- a/tests/fetcher/handlers/test_l0_fetcher.py
+++ b/tests/fetcher/handlers/test_l0_fetcher.py
@@ -85,14 +85,16 @@ def test_notify_queue():
         "send_message",
         {"ResponseMetadata": {"HTTPStatusCode": 200}},
         expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "bucket/file1",
+            "object": "file1",
+            "bucket": bucket,
         })}
     )
     stubber.add_response(
         "send_message",
         {"ResponseMetadata": {"HTTPStatusCode": 200}},
         expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "bucket/file2",
+            "object": "file2",
+            "bucket": bucket,
         })}
     )
     stubber.activate()
@@ -119,14 +121,16 @@ def test_notify_queue_returns_failed():
         "send_message",
         response,
         expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "bucket/file1",
+            "object": "file1",
+            "bucket": bucket,
         })}
     )
     stubber.add_response(
         "send_message",
         {"ResponseMetadata": {"HTTPStatusCode": 200}},
         expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "bucket/file2",
+            "object": "file2",
+            "bucket": bucket,
         })}
     )
     stubber.activate()


### PR DESCRIPTION
Part of https://github.com/innosat-mats/level1a-platform/issues/14

Changes queue type to FIFO and notifies one file at a time.
This changes format for messages so will have to make a synchronized approach to deploying this and the listeners