### PR TITLE
Add parameter to sqs message required by fifo

### DIFF
--- a/fetcher/handlers/l0_fetcher.py
+++ b/fetcher/handlers/l0_fetcher.py
@@ -86,7 +86,8 @@ def notify_queue(
             MessageBody=json.dumps({
                 "object": file,
                 "bucket": bucket,
-            })
+            }),
+            MessageGroupId="parquet",
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             fails.append(file)

--- a/tests/fetcher/handlers/test_l0_fetcher.py
+++ b/tests/fetcher/handlers/test_l0_fetcher.py
@@ -84,18 +84,26 @@ def test_notify_queue():
     stubber.add_response(
         "send_message",
         {"ResponseMetadata": {"HTTPStatusCode": 200}},
-        expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "file1",
-            "bucket": bucket,
-        })}
+        expected_params={
+            "QueueUrl": queue_url,
+            "MessageBody": json.dumps({
+                "object": "file1",
+                "bucket": bucket,
+            }),
+            "MessageGroupId": "parquet",
+        }
     )
     stubber.add_response(
         "send_message",
         {"ResponseMetadata": {"HTTPStatusCode": 200}},
-        expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "file2",
-            "bucket": bucket,
-        })}
+        expected_params={
+            "QueueUrl": queue_url,
+            "MessageBody": json.dumps({
+                "object": "file2",
+                "bucket": bucket,
+            }),
+            "MessageGroupId": "parquet",
+        }
     )
     stubber.activate()
 
@@ -120,18 +128,26 @@ def test_notify_queue_returns_failed():
     stubber.add_response(
         "send_message",
         response,
-        expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "file1",
-            "bucket": bucket,
-        })}
+        expected_params={
+            "QueueUrl": queue_url,
+            "MessageBody": json.dumps({
+                "object": "file1",
+                "bucket": bucket,
+            }),
+            "MessageGroupId": "parquet",
+        }
     )
     stubber.add_response(
         "send_message",
         {"ResponseMetadata": {"HTTPStatusCode": 200}},
-        expected_params={"QueueUrl": queue_url, "MessageBody": json.dumps({
-            "object": "file2",
-            "bucket": bucket,
-        })}
+        expected_params={
+            "QueueUrl": queue_url,
+            "MessageBody": json.dumps({
+                "object": "file2",
+                "bucket": bucket,
+            }),
+            "MessageGroupId": "parquet",
+        }
     )
     stubber.activate()
 


### PR DESCRIPTION
`MessageGroupId` is a required parameter when sending messages to a FIFO queue. It is used to group different types of messages within the same queue