### PR TITLE
Enable content based deduplication for notification queues

### DIFF
--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -46,6 +46,7 @@ class L0FetcherStack(Stack):
             fifo=True,
             retention_period=queue_retention,
             visibility_timeout=queue_visibility_timeout,
+            content_based_deduplication=True,
         )
 
         rclone_layer = LayerVersion.from_layer_version_arn(


### PR DESCRIPTION
Required by FIFO, unless specifying deduplication ids for each message but this seemed like a better choice