### PR TITLE
Review of messup

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,14 +2,22 @@
 
 from aws_cdk import App
 
-from fetcher.l0_fetcher_stack import L0FetcherStack
+from fetcher.l0_fetcher_stack import (
+    L0FetcherStack,
+    RAC_BUCKET,
+    RAC_STACK,
+    PLATFORM_BUCKET,
+    PLATFORM_STACK,
+    SCHEDULE_BUCKET,
+    SCHEDULE_STACK,
+)
 
 app = App()
 
 L0FetcherStack(
     app,
-    "L0RACFetcherStack",
-    output_bucket_name="ops-payload-level0-source",
+    RAC_STACK,
+    output_bucket_name=RAC_BUCKET,
     config_ssm_name="/rclone/l0-fetcher",
     source_path="/pub/OPS/TM/Level0/VC1/APID100/",
     rclone_arn="arn:aws:lambda:eu-north-1:671150066425:layer:rclone-amd64:1",
@@ -18,8 +26,8 @@ L0FetcherStack(
 
 L0FetcherStack(
     app,
-    "L0PlatformFetcherStack",
-    output_bucket_name="ops-platform-level1a-source-v0.1",
+    PLATFORM_STACK,
+    output_bucket_name=PLATFORM_BUCKET,
     config_ssm_name="/rclone/l0-fetcher",
     source_path="/pub/OPS/TM/Level1A/Platform_v1/",
     rclone_arn="arn:aws:lambda:eu-north-1:671150066425:layer:rclone-amd64:1",
@@ -28,8 +36,8 @@ L0FetcherStack(
 
 L0FetcherStack(
     app,
-    "L0ScheduleFetcherStack",
-    output_bucket_name="ops-schedule-level0-source-v0.1",
+    SCHEDULE_STACK,
+    output_bucket_name=SCHEDULE_BUCKET,
     config_ssm_name="/rclone/l0-fetcher",
     source_path="/pub/Timeline/Schedule/",
     rclone_arn="arn:aws:lambda:eu-north-1:671150066425:layer:rclone-amd64:1",

--- a/app.py
+++ b/app.py
@@ -26,4 +26,14 @@ L0FetcherStack(
     full_sync=True,
 )
 
+L0FetcherStack(
+    app,
+    "L0ScheduleFetcherStack",
+    output_bucket_name="ops-schedule-level0-source-v0.1",
+    config_ssm_name="/rclone/l0-fetcher",
+    source_path="/pub/Timeline/Schedule/",
+    rclone_arn="arn:aws:lambda:eu-north-1:671150066425:layer:rclone-amd64:1",
+    full_sync=True,
+)
+
 app.synth()

--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -15,12 +15,21 @@ from aws_cdk.aws_sqs import DeadLetterQueue, Queue
 from constructs import Construct
 
 
+RAC_BUCKET = "ops-payload-level0-source"
+RAC_STACK = "L0RACFetcherStack"
+PLATFORM_BUCKET = "ops-platform-level1a-source-v0.1"
+PLATFORM_STACK = "L0PlatformFetcherStack"
+SCHEDULE_BUCKET = "ops-schedule-source-v0.1"
+SCHEDULE_STACK = "L0ScheduleFetcherStack"
+TEMPLATE_OUTPUT_QUEUE = "{stack_name}OutputQueue"
+
+
 class L0FetcherStack(Stack):
 
     def __init__(
         self,
         scope: Construct,
-        id: str,
+        stack_id: str,
         output_bucket_name: str,
         config_ssm_name: str,
         source_path: str,
@@ -32,7 +41,7 @@ class L0FetcherStack(Stack):
         queue_visibility_timeout: Duration = Duration.minutes(10),
         **kwargs
     ) -> None:
-        super().__init__(scope, id, **kwargs)
+        super().__init__(scope, stack_id, **kwargs)
 
         output_bucket = Bucket.from_bucket_name(
             self,
@@ -104,5 +113,5 @@ class L0FetcherStack(Stack):
             self,
             "QueueOutput",
             value=notification_queue.queue_arn,
-            export_name=f"{id}OutputQueue",
+            export_name=TEMPLATE_OUTPUT_QUEUE.format(stack_name=stack_id),
         )

--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -29,7 +29,7 @@ class L0FetcherStack(Stack):
     def __init__(
         self,
         scope: Construct,
-        stack_id: str,
+        id: str,
         output_bucket_name: str,
         config_ssm_name: str,
         source_path: str,
@@ -41,7 +41,7 @@ class L0FetcherStack(Stack):
         queue_visibility_timeout: Duration = Duration.minutes(10),
         **kwargs
     ) -> None:
-        super().__init__(scope, stack_id, **kwargs)
+        super().__init__(scope, id, **kwargs)
 
         output_bucket = Bucket.from_bucket_name(
             self,
@@ -113,5 +113,5 @@ class L0FetcherStack(Stack):
             self,
             "QueueOutput",
             value=notification_queue.queue_arn,
-            export_name=TEMPLATE_OUTPUT_QUEUE.format(stack_name=stack_id),
+            export_name=TEMPLATE_OUTPUT_QUEUE.format(stack_name=id),
         )

--- a/fetcher/l0_fetcher_stack.py
+++ b/fetcher/l0_fetcher_stack.py
@@ -19,7 +19,7 @@ RAC_BUCKET = "ops-payload-level0-source"
 RAC_STACK = "L0RACFetcherStack"
 PLATFORM_BUCKET = "ops-platform-level1a-source-v0.1"
 PLATFORM_STACK = "L0PlatformFetcherStack"
-SCHEDULE_BUCKET = "ops-schedule-source-v0.1"
+SCHEDULE_BUCKET = "ops-mats-schedule-source-v0.1"
 SCHEDULE_STACK = "L0ScheduleFetcherStack"
 TEMPLATE_OUTPUT_QUEUE = "{stack_name}OutputQueue"
 

--- a/rerun.py
+++ b/rerun.py
@@ -18,6 +18,10 @@ class FetcherService(Enum):
         "ops-platform-level1a-source-v0.1",  # bucket
         "L0PlatformFetcherStackOutputQueue",  # cfn-key
     )
+    SCHEDULE = (
+        "ops-schedule-source-v0.1",  # bucket
+        "L0ScheduleFetcherStackOutputQueue",  # cfn-key
+    )
 
     @property
     def bucket(self) -> str:

--- a/rerun.py
+++ b/rerun.py
@@ -6,21 +6,30 @@ from fetcher.handlers.l0_fetcher import (
     notify_queue,
     BotoClient,
 )
+from fetcher.l0_fetcher_stack import (
+    PLATFORM_BUCKET,
+    PLATFORM_STACK,
+    RAC_BUCKET,
+    RAC_STACK,
+    SCHEDULE_BUCKET,
+    SCHEDULE_STACK,
+    TEMPLATE_OUTPUT_QUEUE,
+)
 
 
 @unique
 class FetcherService(Enum):
     RAC_PAYLOAD = (
-        "ops-payload-level0-source",  # bucket
-        "L0RACFetcherStackOutputQueue",  # cfn-key
+        RAC_BUCKET,  # bucket
+        TEMPLATE_OUTPUT_QUEUE.format(stack_name=RAC_STACK)  # cfn-key
     )
     H5_PLATFORM = (
-        "ops-platform-level1a-source-v0.1",  # bucket
-        "L0PlatformFetcherStackOutputQueue",  # cfn-key
+        PLATFORM_BUCKET,  # bucket
+        TEMPLATE_OUTPUT_QUEUE.format(stack_name=PLATFORM_STACK)  # cfn-key
     )
     SCHEDULE = (
-        "ops-schedule-source-v0.1",  # bucket
-        "L0ScheduleFetcherStackOutputQueue",  # cfn-key
+        SCHEDULE_BUCKET,  # bucket
+        TEMPLATE_OUTPUT_QUEUE.format(stack_name=SCHEDULE_STACK)  # cfn-key
     )
 
     @property


### PR DESCRIPTION
I made some changes to implement a new stack for the schedule fetcher and must have missed a `-b` when checking out a new branch. Rather than do the revert dance, I thought I would try this for just a review. Changes are not deployed, but are already in main, hence the weird PR from `main` to `dummy`. If you prefer, I can revert and make a proper PR.

This:
- implements new fetcher stack for schedule,
- adds support for said stack in rerun script, and
- makes script and app both use the same definitions for buckets and queues.

First part of